### PR TITLE
Don't delete deployment files shared with other stacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pacploy",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Package and deploy CloudFormation templates with a simple CLI",
   "author": "Romain Vermeulen",
   "license": "MIT",

--- a/src/pacploy/cleanup/getPackagedFilesToPrune.js
+++ b/src/pacploy/cleanup/getPackagedFilesToPrune.js
@@ -79,8 +79,10 @@ async function getFilesToPruneInBucket(region, bucket, stacks, exclude) {
 
   // Map the files to the stack(s) they pertain to
   return filesToPruneInBucket.reduce((perStack, { tags, ...object }) => {
-    // Retrieve the list of stacks to which the file belongs
-    const stackNames = typeof tags === "object" ? tags.RootStackName || [] : []
+    // Retrieve the list of stacks to which the file belongs (exclude empty
+    // values that may have ended up in the file's tags)
+    const stackNames =
+      typeof tags === "object" ? tags.RootStackName.filter(Boolean) || [] : []
     for (const stackName of stackNames) {
       // Generate the stack's id in the expected format
       const id = `${region}|${stackName}`

--- a/src/pacploy/cleanup/prunePackagedFiles.js
+++ b/src/pacploy/cleanup/prunePackagedFiles.js
@@ -99,8 +99,14 @@ export default async function prunePackagedFiles(stacks) {
   Object.values(prunableStacks).forEach((buckets) =>
     Object.values(buckets).forEach((stacks) =>
       Object.keys(stacks).forEach((id) => {
-        if (_stacks[id].forceDelete) stackIdsToPrune.push(id)
-        else stackIdsToConfirm.push(id)
+        // If the current stack is not in the list of stacks we are handling,
+        // leave it as unconfirmed so that the file won't be deleted (we do it
+        // by not marking it as auto-delete nor including it in the list of
+        // stacks to manually confirm)
+        if (id in Object.keys(_stacks)) {
+          if (_stacks[id].forceDelete) stackIdsToPrune.push(id)
+          else stackIdsToConfirm.push(id)
+        }
       })
     )
   )

--- a/src/pacploy/del/index.js
+++ b/src/pacploy/del/index.js
@@ -6,13 +6,20 @@ import getStatus from "../getStatus/index.js"
 /**
  * Delete stacks while respecting their dependencies
  * @param {import('../params/index.js').default|import('../params/index.js').default[]} stacks
+ * @param {Object} [params] Additional parameters
+ * @param {Boolean} [params.warnAboutForceDelete=true] Enable to deactivate the
+ * warning about the forceDelete flag when it was already displayed
  * The list of stack parameters to delete
  */
-export default async function del(stacks) {
+export default async function del(
+  stacks,
+  { warnAboutForceDelete = true } = {}
+) {
   if (!Array.isArray(stacks)) stacks = [stacks] // Convert to array
 
   // Check if at least one forceDelete parameter is set
   if (
+    warnAboutForceDelete &&
     stacks.reduce(
       (hasForceDelete, { forceDelete }) => hasForceDelete || forceDelete,
       false

--- a/src/pacploy/deploy/prepare.js
+++ b/src/pacploy/deploy/prepare.js
@@ -35,7 +35,7 @@ export default async function prepare(stack) {
         ].join(" ")
       )
     // Delete stack
-    await del(stack)
+    await del(stack, { warnAboutForceDelete: false })
     // Update status
     status = await getStatus({ region, stackName })
   }


### PR DESCRIPTION
If a deployment file is used by a stack not included in the list of stacks to handle, don't delete it. This also fixes an error which was raised when encountering an empty stack name or a foreign one in the file's tags.