### PR TITLE
Fix dotenv encoding during sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pacploy",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pacploy",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-athena": "^3.267.0",
@@ -22,7 +22,6 @@
         "ansi-colors": "^4.1.3",
         "archiver": "^5.3.1",
         "dockerode": "^3.3.4",
-        "dotenv": "^16.0.3",
         "enquirer": "^2.3.6",
         "find-up": "^6.3.0",
         "glob": "^9.3.4",
@@ -51,7 +50,7 @@
         "prettier": "^3.0.2"
       },
       "engines": {
-        "node": "^14.13.1 || >=16.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -12618,17 +12617,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -27240,11 +27228,6 @@
       "requires": {
         "esutils": "^2.0.2"
       }
-    },
-    "dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
     },
     "electron-to-chromium": {
       "version": "1.4.477",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,13 +42,13 @@
         "@types/jest": "^29.4.0",
         "babel-jest": "^29.4.2",
         "eslint": "^8.34.0",
-        "eslint-config-prettier": "^8.6.0",
+        "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-jest": "^27.2.1",
         "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-prettier": "^5.0.0",
         "jest": "29.6.1",
-        "prettier": "^2.8.4"
+        "prettier": "^3.0.2"
       },
       "engines": {
         "node": "^14.13.1 || >=16.0.0"
@@ -9763,6 +9763,32 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pkgr/utils": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
+      "integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "fast-glob": "^3.3.0",
+        "is-glob": "^4.0.3",
+        "open": "^9.1.0",
+        "picocolors": "^1.0.0",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -11330,9 +11356,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -11919,6 +11945,15 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -11956,6 +11991,18 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
+    "node_modules/bplist-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+      "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+      "dev": true,
+      "dependencies": {
+        "big-integer": "^1.6.44"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -12041,6 +12088,21 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/bundle-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+      "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+      "dev": true,
+      "dependencies": {
+        "run-applescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -12315,6 +12377,162 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
+      "integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
+      "dev": true,
+      "dependencies": {
+        "bundle-name": "^3.0.0",
+        "default-browser-id": "^3.0.0",
+        "execa": "^7.1.1",
+        "titleize": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
+      "integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
+      "dev": true,
+      "dependencies": {
+        "bplist-parser": "^0.2.0",
+        "untildify": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/execa": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^4.3.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/default-browser/node_modules/human-signals": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/default-browser/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
@@ -12632,9 +12850,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
-      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
+      "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
@@ -12806,21 +13024,29 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
+      "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
       "dev": true,
       "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.5"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/prettier"
       },
       "peerDependencies": {
-        "eslint": ">=7.28.0",
-        "prettier": ">=2.0.0"
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "prettier": ">=3.0.0"
       },
       "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
         "eslint-config-prettier": {
           "optional": true
         }
@@ -13155,9 +13381,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -13822,6 +14048,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -13858,6 +14099,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-negative-zero": {
@@ -14004,6 +14263,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-wsl/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -15241,6 +15527,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+      "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+      "dev": true,
+      "dependencies": {
+        "default-browser": "^4.0.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -15498,15 +15802,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -15864,6 +16168,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+      "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-parallel": {
@@ -16247,6 +16566,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
+      "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/utils": "^2.3.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/synckit/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
     "node_modules/tar-fs": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
@@ -16312,6 +16653,18 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "node_modules/titleize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
+      "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tmp": {
       "version": "0.2.1",
@@ -16574,6 +16927,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -24590,6 +24952,28 @@
         "fastq": "^1.6.0"
       }
     },
+    "@pkgr/utils": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
+      "integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "fast-glob": "^3.3.0",
+        "is-glob": "^4.0.3",
+        "open": "^9.1.0",
+        "picocolors": "^1.0.0",
+        "tslib": "^2.6.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
+        }
+      }
+    },
     "@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -25970,9 +26354,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -26393,6 +26777,12 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "dev": true
+    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -26418,6 +26808,15 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
+    "bplist-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+      "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+      "dev": true,
+      "requires": {
+        "big-integer": "^1.6.44"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -26477,6 +26876,15 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "bundle-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+      "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+      "dev": true,
+      "requires": {
+        "run-applescript": "^5.0.0"
+      }
     },
     "call-bind": {
       "version": "1.0.2",
@@ -26675,6 +27083,101 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true
+    },
+    "default-browser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
+      "integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
+      "dev": true,
+      "requires": {
+        "bundle-name": "^3.0.0",
+        "default-browser-id": "^3.0.0",
+        "execa": "^7.1.1",
+        "titleize": "^3.0.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+          "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.1",
+            "human-signals": "^4.3.0",
+            "is-stream": "^3.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^5.1.0",
+            "onetime": "^6.0.0",
+            "signal-exit": "^3.0.7",
+            "strip-final-newline": "^3.0.0"
+          }
+        },
+        "human-signals": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+          "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+          "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+          "dev": true,
+          "requires": {
+            "path-key": "^4.0.0"
+          }
+        },
+        "onetime": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^4.0.0"
+          }
+        },
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+          "dev": true
+        },
+        "strip-final-newline": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+          "dev": true
+        }
+      }
+    },
+    "default-browser-id": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
+      "integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
+      "dev": true,
+      "requires": {
+        "bplist-parser": "^0.2.0",
+        "untildify": "^4.0.0"
+      }
+    },
+    "define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
       "dev": true
     },
     "define-properties": {
@@ -27001,9 +27504,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
-      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
+      "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
       "dev": true,
       "requires": {}
     },
@@ -27128,12 +27631,13 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
+      "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
       "dev": true,
       "requires": {
-        "prettier-linter-helpers": "^1.0.0"
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.5"
       }
     },
     "eslint-scope": {
@@ -27276,9 +27780,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -27755,6 +28259,12 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -27779,6 +28289,15 @@
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
+      }
+    },
+    "is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^3.0.0"
       }
     },
     "is-negative-zero": {
@@ -27871,6 +28390,23 @@
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2"
+      }
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^2.0.0"
+      },
+      "dependencies": {
+        "is-docker": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+          "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+          "dev": true
+        }
       }
     },
     "isarray": {
@@ -28822,6 +29358,18 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "open": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+      "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+      "dev": true,
+      "requires": {
+        "default-browser": "^4.0.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^2.2.0"
+      }
+    },
     "optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -29002,9 +29550,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -29253,6 +29801,15 @@
             "path-is-absolute": "^1.0.0"
           }
         }
+      }
+    },
+    "run-applescript": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+      "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+      "dev": true,
+      "requires": {
+        "execa": "^5.0.0"
       }
     },
     "run-parallel": {
@@ -29533,6 +30090,24 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "synckit": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
+      "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
+      "dev": true,
+      "requires": {
+        "@pkgr/utils": "^2.3.1",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
+        }
+      }
+    },
     "tar-fs": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
@@ -29587,6 +30162,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "titleize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
+      "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
       "dev": true
     },
     "tmp": {
@@ -29779,6 +30360,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
       "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
+      "dev": true
+    },
+    "untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
       "dev": true
     },
     "update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pacploy",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Package and deploy CloudFormation templates with a simple CLI",
   "author": "Romain Vermeulen",
   "license": "MIT",
@@ -34,7 +34,7 @@
   "scripts": {
     "test": "jest",
     "lint": "eslint .",
-    "format": "eslint --cache --fix $(git ls-files '*.js') && prettier --write $(git ls-files '*.js')",
+    "format": "eslint --fix $(git ls-files '*.js')",
     "doctoc": "doctoc --title='## Table of Contents' --github README.md"
   },
   "dependencies": {
@@ -68,13 +68,13 @@
     "@types/jest": "^29.4.0",
     "babel-jest": "^29.4.2",
     "eslint": "^8.34.0",
-    "eslint-config-prettier": "^8.6.0",
+    "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-prettier": "^5.0.0",
     "jest": "29.6.1",
-    "prettier": "^2.8.4"
+    "prettier": "^3.0.2"
   },
   "files": [
     "LICENSE",
@@ -85,7 +85,7 @@
     "src/**/*.js"
   ],
   "engines": {
-    "node": "^14.13.1 || >=16.0.0"
+    "node": ">=16.0.0"
   },
   "prettier": {
     "semi": false

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "ansi-colors": "^4.1.3",
     "archiver": "^5.3.1",
     "dockerode": "^3.3.4",
-    "dotenv": "^16.0.3",
     "enquirer": "^2.3.6",
     "find-up": "^6.3.0",
     "glob": "^9.3.4",

--- a/src/bin.js
+++ b/src/bin.js
@@ -29,14 +29,14 @@ if (cliArgs.includes("--stack-name"))
   // configurations matching it
   confs = confs.filter(
     ({ stackName } = { stackName: undefined }) =>
-      stackName === cliArgs[cliArgs.indexOf("--stack-name") + 1]
+      stackName === cliArgs[cliArgs.indexOf("--stack-name") + 1],
   )
 // Keep at least an empty conf object to process the CLI args
 if (confs.length === 0) confs.push({})
 
 // Resolve the arguments to use for each user-defined configuration
 let args = await Promise.all(
-  confs.map((curConf) => parseCommandArgs(commandDir, curConf, cliArgs))
+  confs.map((curConf) => parseCommandArgs(commandDir, curConf, cliArgs)),
 )
 // Some commands are not compatible with a list of stacks
 if (["zip", "errors"].includes(commandName) && args.length >= 1)
@@ -122,12 +122,12 @@ async function applyCommandDir(commandDir, args) {
   // Retrieve the commands definitions
   const files = await new Promise((res, rej) =>
     // Read all files from supplied directory
-    readdir(commandDir, (err, files) => (err ? rej(err) : res(files)))
+    readdir(commandDir, (err, files) => (err ? rej(err) : res(files))),
   )
   const commands = await Promise.all(
     files
       .filter((file) => file.endsWith(".js")) // Keep only JS files
-      .map((file) => import(join(commandDir, file))) // Import module
+      .map((file) => import(join(commandDir, file))), // Import module
   )
   const commandDefs = commands.map((module) => module.default)
 
@@ -137,7 +137,7 @@ async function applyCommandDir(commandDir, args) {
       commandDef.command,
       commandDef.describe,
       commandDef.builder || {},
-      commandDef.handler
+      commandDef.handler,
     )
   return args
 }

--- a/src/pacploy/cleanup/deleteResource.js
+++ b/src/pacploy/cleanup/deleteResource.js
@@ -88,7 +88,7 @@ async function deleteS3Bucket(region, bucket) {
     new DeleteBucketCommand({
       Bucket: bucket,
       credentialDefaultProvider,
-    })
+    }),
   )
 }
 
@@ -106,7 +106,7 @@ async function deleteECR(region, repositoryName) {
   await call(
     ecr,
     ecr.send,
-    new DeleteRepositoryCommand({ repositoryName, force: true })
+    new DeleteRepositoryCommand({ repositoryName, force: true }),
   )
 }
 
@@ -147,15 +147,15 @@ async function deleteCognitoUserPool(region, userPoolId, arn) {
           await call(
             userPool,
             userPool.send,
-            new ListTagsForIdentityProviderCommand({ ResourceArn: arn })
-          )
+            new ListTagsForIdentityProviderCommand({ ResourceArn: arn }),
+          ),
         ),
-      })
+      }),
     )
     await call(
       userPool,
       userPool.send,
-      new DeleteUserPoolCommand({ UserPoolId: userPoolId })
+      new DeleteUserPoolCommand({ UserPoolId: userPoolId }),
     )
   } catch (err) {
     if (err.code !== "ResourceNotFoundException")
@@ -191,17 +191,17 @@ async function deleteCognitoIdentityPool(region, identityPoolId, arn) {
             identityPool.send,
             new ListTagsForCognitoPoolCommand({
               ResourceArn: arn,
-            })
-          )
+            }),
+          ),
         ),
-      })
+      }),
     )
     await call(
       identityPool,
       identityPool.send,
       new DeleteIdentityPoolCommand({
         IdentityPoolId: identityPoolId,
-      })
+      }),
     )
   } catch (err) {
     if (err.code !== "ResourceNotFoundException")
@@ -230,6 +230,6 @@ async function deleteAthenaWorkgroup(region, workgroup) {
       WorkGroup: workgroup,
       // Delete any named queries or query executions
       RecursiveDeleteOption: true,
-    })
+    }),
   )
 }

--- a/src/pacploy/cleanup/emptyBucket.js
+++ b/src/pacploy/cleanup/emptyBucket.js
@@ -38,7 +38,7 @@ export default async function emptyBucket({
         exclude,
       },
       nextVersionIdMarker,
-      nextKeyMarker
+      nextKeyMarker,
     )
     // Delete the object versions
     if (objects.length > 0) {
@@ -53,7 +53,7 @@ export default async function emptyBucket({
               VersionId: versionId,
             })),
           },
-        })
+        }),
       )
       deleted = deleted.concat(objects.map(({ key }) => key))
     }

--- a/src/pacploy/cleanup/getPackagedFilesInUse.js
+++ b/src/pacploy/cleanup/getPackagedFilesInUse.js
@@ -17,8 +17,8 @@ export default async function getPackagedFilesInUse(stacks) {
         stacks.map(async ({ region, stackName, deployBucket }) =>
           (await getStatus({ region, stackName })) === "NEW"
             ? []
-            : await listPackagedFiles({ region, stackName, deployBucket })
-        )
+            : await listPackagedFiles({ region, stackName, deployBucket }),
+        ),
       )
     )
       // De-duplicate the files in use and group them by bucket

--- a/src/pacploy/cleanup/getPackagedFilesToPrune.js
+++ b/src/pacploy/cleanup/getPackagedFilesToPrune.js
@@ -26,19 +26,19 @@ export default async function getPackagedFilesToPrune(stacksToPrune, exclude) {
                 region,
                 bucket,
                 stacks,
-                (exclude[region] || {})[bucket]
+                (exclude[region] || {})[bucket],
               )
               if (Object.keys(filesToPruneInBucket).length > 0)
                 // If there are any files to prune in the bucket
                 return { [bucket]: filesToPruneInBucket }
-            })
-          ))
+            }),
+          )),
         )
         if (Object.keys(filesToPruneInRegion).length > 0)
           // If there are any files to prune in the region
           return { [region]: filesToPruneInRegion }
-      })
-    ))
+      }),
+    )),
   )
 }
 
@@ -72,7 +72,7 @@ async function getFilesToPruneInBucket(region, bucket, stacks, exclude) {
         exclude,
       },
       nextVersionIdMarker,
-      nextKeyMarker
+      nextKeyMarker,
     )
     filesToPruneInBucket = filesToPruneInBucket.concat(objects)
   } while (nextVersionIdMarker || nextKeyMarker)

--- a/src/pacploy/cleanup/index.js
+++ b/src/pacploy/cleanup/index.js
@@ -13,7 +13,7 @@ import pruneRetainedResources from "./pruneRetainedResources.js"
  */
 export default async function cleanup(
   stacks,
-  { warnAboutForceDelete = true } = {}
+  { warnAboutForceDelete = true } = {},
 ) {
   if (!Array.isArray(stacks)) stacks = [stacks] // Convert to array
 
@@ -22,7 +22,7 @@ export default async function cleanup(
     warnAboutForceDelete &&
     stacks.reduce(
       (hasForceDelete, { forceDelete }) => hasForceDelete || forceDelete,
-      false
+      false,
     )
   )
     // Warn user that we may not ask for confirmation before deleting

--- a/src/pacploy/cleanup/listBucket.js
+++ b/src/pacploy/cleanup/listBucket.js
@@ -31,7 +31,7 @@ export const tagDelimiter = ":"
 export default async function listBucket(
   { region, bucket, tagsFilters, exclude = [], pageSize = 1000 },
   versionIdMarker,
-  keyMarker
+  keyMarker,
 ) {
   const s3 = new S3Client({
     apiVersion: "2006-03-01",
@@ -53,7 +53,7 @@ export default async function listBucket(
       MaxKeys: pageSize,
       VersionIdMarker: versionIdMarker,
       KeyMarker: keyMarker,
-    })
+    }),
   )
 
   // Filter out keys that were excluded and format as expected
@@ -75,12 +75,12 @@ export default async function listBucket(
               Object.entries(tagsFilter).reduce(
                 (isMatch, [tagName, tagValue]) =>
                   isMatch && (tags[tagName] || []).includes(tagValue),
-                true
+                true,
               )
             )
               // If the tags match the current set, include the object
               return { ...object, tags }
-        })
+        }),
       )
     ).filter(Boolean) // Remove filtered-out objects
 
@@ -103,7 +103,7 @@ export async function getTags(region, bucket, key) {
   const { TagSet } = await call(
     s3,
     s3.send,
-    new GetObjectTaggingCommand({ Bucket: bucket, Key: key })
+    new GetObjectTaggingCommand({ Bucket: bucket, Key: key }),
   )
   // De-serialize the TagSet
   return TagSet.reduce((tags, { Key, Value }) => {

--- a/src/pacploy/cleanup/listLiveResourceArns.js
+++ b/src/pacploy/cleanup/listLiveResourceArns.js
@@ -35,13 +35,13 @@ export default async function listLiveResourceArns({
     new ListStackResourcesCommand({
       StackName: stackName,
       NextToken: nextToken,
-    })
+    }),
   )
   // Retrieve region and account ID from the current stack arn
   const { Stacks: [{ StackId }] = [] } = await call(
     cf,
     cf.send,
-    new DescribeStacksCommand({ StackName: stackName })
+    new DescribeStacksCommand({ StackName: stackName }),
   )
   const accountId = StackId.split(":")[4]
   // Extract the resources arns, including those in nested stacks
@@ -50,7 +50,7 @@ export default async function listLiveResourceArns({
     await StackResourceSummaries.reduce(
       async (
         res,
-        { ResourceType: resourceType, PhysicalResourceId: physicalResourceId }
+        { ResourceType: resourceType, PhysicalResourceId: physicalResourceId },
       ) => {
         res = await res // Retrieve current value, as this is an async reducer
         if (resourceType === "AWS::CloudFormation::Stack")
@@ -59,7 +59,7 @@ export default async function listLiveResourceArns({
             await listLiveResourceArns({
               region,
               stackName: physicalResourceId,
-            })
+            }),
           )
         else if (Object.values(supported).includes(resourceType))
           // If the resource is supported to be deleted. We ignore other
@@ -71,12 +71,12 @@ export default async function listLiveResourceArns({
               physicalResourceId,
               accountId,
               region,
-            })
+            }),
           )
         return res
       },
-      Promise.resolve([])
-    )
+      Promise.resolve([]),
+    ),
   )
   // If resources span multiple pages, recursively retrieve them
   return NextToken
@@ -85,7 +85,7 @@ export default async function listLiveResourceArns({
           region,
           stackName,
           nextToken: NextToken,
-        })
+        }),
       )
     : resources
 }
@@ -124,7 +124,7 @@ function getResourceArn({
     case "AWS::SQS::Queue":
       return physicalResourceId.replace(
         `https://sqs.${region}.amazonaws.com/${accountId}/`,
-        `arn:aws:sqs:${region}:${accountId}:`
+        `arn:aws:sqs:${region}:${accountId}:`,
       )
     case "AWS::Events::Rule":
       return `arn:aws:events:${region}:${accountId}:rule/${physicalResourceId}`
@@ -142,7 +142,7 @@ function getResourceArn({
         throw new Error(
           `The arn of resource ${resourceType}` +
             ` ${physicalResourceId} could not be generated and the` +
-            ` resource would be deleted inadvertently`
+            ` resource would be deleted inadvertently`,
         )
   }
 }

--- a/src/pacploy/cleanup/listRetainedResourceArns.js
+++ b/src/pacploy/cleanup/listRetainedResourceArns.js
@@ -39,17 +39,17 @@ export default async function listRetainedResourceArns({
     new GetResourcesCommand({
       PaginationToken: nextToken,
       TagFilters: [{ Key: "RootStackName", Values: [stackName] }],
-    })
+    }),
   )
   // Extract resources ARN
   const resources = ResourceTagMappingList.map(
-    ({ ResourceARN }) => ResourceARN
+    ({ ResourceARN }) => ResourceARN,
   ).filter(
     (arn) =>
       // Exclude resources that were explicitely requested to be excluded, or
       // whose type is not supported for deletion
       !exclude.includes(arn) &&
-      Object.keys(supported).includes(arn.split(":")[2])
+      Object.keys(supported).includes(arn.split(":")[2]),
   )
   // If resources span multiple pages, recursively retrieve them
   return PaginationToken
@@ -59,7 +59,7 @@ export default async function listRetainedResourceArns({
           stackName,
           nextToken: PaginationToken,
           exclude,
-        })
+        }),
       )
     : resources
 }

--- a/src/pacploy/cleanup/prunePackagedFiles.js
+++ b/src/pacploy/cleanup/prunePackagedFiles.js
@@ -57,7 +57,7 @@ export default async function prunePackagedFiles(stacks) {
       grouped[region][deployBucket][id] = stack
       return grouped
     },
-    {}
+    {},
   )
 
   // If there are no stacks to prune, don't proceed further
@@ -68,9 +68,9 @@ export default async function prunePackagedFiles(stacks) {
         Object.values(buckets).reduce(
           (perBucketCount, stacks) =>
             perBucketCount + Object.keys(stacks).length,
-          0
+          0,
         ),
-      0
+      0,
     ) === 0
   )
     return
@@ -85,7 +85,7 @@ export default async function prunePackagedFiles(stacks) {
   // Retrieve the region, bucket and list of files to prune for each stack
   const prunableStacks = await getPackagedFilesToPrune(
     stacksToPrune,
-    filesInUse
+    filesInUse,
   )
   if (Object.keys(prunableStacks).length === 0) {
     tracker.interruptInfo("No files to prune")
@@ -107,8 +107,8 @@ export default async function prunePackagedFiles(stacks) {
           if (_stacks[id].forceDelete) stackIdsToPrune.push(id)
           else stackIdsToConfirm.push(id)
         }
-      })
-    )
+      }),
+    ),
   )
   if (stackIdsToConfirm.length > 0) {
     // Ask for user confirmation if needed
@@ -135,12 +135,12 @@ export default async function prunePackagedFiles(stacks) {
   if (stackIdsToPrune.length > 0) {
     const s = stackIdsToPrune.length > 1 ? "s" : ""
     tracker.setStatus(
-      `pruning old deployment files of ${stackIdsToPrune.length} stack${s}`
+      `pruning old deployment files of ${stackIdsToPrune.length} stack${s}`,
     )
     const prunedKeysCount = await pruneFiles(prunableStacks, stackIdsToPrune)
     // Display the number of pruned files
     tracker[prunedKeysCount ? "interruptSuccess" : "interruptInfo"](
-      `${prunedKeysCount ? prunedKeysCount : "No"} unused files pruned`
+      `${prunedKeysCount ? prunedKeysCount : "No"} unused files pruned`,
     )
   }
 }
@@ -192,22 +192,22 @@ async function pruneFiles(prunableStacks, stackIdsToPrune) {
                       VersionId: versionId,
                     })),
                   },
-                })
-              )
-            )
+                }),
+              ),
+            ),
           )
           // Return the list of pruned objects in the bucket
           return objectsToPrune
-        })
+        }),
       )
       // Return the count of pruned objects in the region
       return prunedObjects.reduce((count, objects) => count + objects.length, 0)
-    })
+    }),
   )
   // Return the count of pruned objects across regions
   return countPerRegion.reduce(
     (count, countPerBucket) => count + countPerBucket,
-    0
+    0,
   )
 }
 

--- a/src/pacploy/cleanup/pruneRetainedResources.js
+++ b/src/pacploy/cleanup/pruneRetainedResources.js
@@ -37,7 +37,7 @@ export default async function pruneRetainedResources(stacks) {
         if ((await getStatus({ region, stackName })) !== "NEW")
           // Don't attempt to collect live resources if stack doesn't exist
           return await listLiveResourceArns({ region, stackName })
-      })
+      }),
     )
   ).flat() // Combine arns across all stacks (will remove inexisting stacks)
 
@@ -52,8 +52,8 @@ export default async function pruneRetainedResources(stacks) {
             stackName,
             exclude: liveResourceArns,
           })
-        ).map((arn) => ({ region, arn, forceDelete }))
-      )
+        ).map((arn) => ({ region, arn, forceDelete })),
+      ),
     )
   ).flat()
 
@@ -65,12 +65,12 @@ export default async function pruneRetainedResources(stacks) {
 
   // Auto-select the resources flagged with forceDelete
   const resourcesToDelete = retainedResources.filter(
-    ({ forceDelete }) => forceDelete
+    ({ forceDelete }) => forceDelete,
   )
 
   // Ask for confirmation for resources not flagged with forceDelete
   const resourcesToConfirm = retainedResources.filter(
-    ({ forceDelete }) => !forceDelete
+    ({ forceDelete }) => !forceDelete,
   )
   if (resourcesToConfirm.length > 0) {
     const { confirmedIds } = await tracker.prompt({
@@ -106,7 +106,7 @@ export default async function pruneRetainedResources(stacks) {
         }
         if (error) tracker.interruptWarn(`Failed to delete ${arn}: ${error}`)
         else tracker.interruptWarn(`Failed to delete ${arn}`)
-      })
+      }),
     )
   ).filter(Boolean) // Remove failed resources
 
@@ -119,13 +119,13 @@ export default async function pruneRetainedResources(stacks) {
           region,
           stackName,
           exclude: liveResourceArns,
-        })
-      )
+        }),
+      ),
     )
   ).flat()
   tracker.interruptInfo(
     `Deleted ${deletedResources.length} retained resources, ${
       retainedResourcesLeft.length ? retainedResourcesLeft.length : "none"
-    } left`
+    } left`,
   )
 }

--- a/src/pacploy/del/deleteStacks.js
+++ b/src/pacploy/del/deleteStacks.js
@@ -36,8 +36,8 @@ export default async function deleteStacks(stacks) {
         updateTracker(stacks)
         // Recursively delete stacks that may have depended on the current one
         return deleteStacks(stacks)
-      }
-    )
+      },
+    ),
   )
 }
 
@@ -49,14 +49,14 @@ export default async function deleteStacks(stacks) {
 function updateTracker(stacks) {
   const total = Object.keys(stacks).length
   const left = Object.values(stacks).filter(
-    ({ deleteStatus }) => !["success", "failed"].includes(deleteStatus)
+    ({ deleteStatus }) => !["success", "failed"].includes(deleteStatus),
   ).length
   const inProgress = Object.values(stacks).filter(
-    ({ deleteStatus }) => deleteStatus === "in progress"
+    ({ deleteStatus }) => deleteStatus === "in progress",
   ).length
   if (total > 1)
     tracker.setStatus(
-      `deleting ${total} stacks (${left} left, ${inProgress} in progress)`
+      `deleting ${total} stacks (${left} left, ${inProgress} in progress)`,
     )
   else tracker.setStatus("deleting stack")
 }
@@ -79,7 +79,7 @@ function getStacksReadyToDelete(stacks) {
       getDependents({ region, stackName }, stacks).reduce(
         (allDeleted, { deleteStatus }) =>
           allDeleted && deleteStatus === "success",
-        true
+        true,
       )
     )
       readyStacks[id] = stack

--- a/src/pacploy/del/index.js
+++ b/src/pacploy/del/index.js
@@ -13,7 +13,7 @@ import getStatus from "../getStatus/index.js"
  */
 export default async function del(
   stacks,
-  { warnAboutForceDelete = true } = {}
+  { warnAboutForceDelete = true } = {},
 ) {
   if (!Array.isArray(stacks)) stacks = [stacks] // Convert to array
 
@@ -22,7 +22,7 @@ export default async function del(
     warnAboutForceDelete &&
     stacks.reduce(
       (hasForceDelete, { forceDelete }) => hasForceDelete || forceDelete,
-      false
+      false,
     )
   )
     // Warn user that we'll not ask for confirmation before deleting
@@ -31,7 +31,7 @@ export default async function del(
   // Resolve stack parameters
   tracker.setStatus("resolving stacks parameters")
   const resolvedStacks = await Promise.all(
-    stacks.map((stack) => stack.resolve())
+    stacks.map((stack) => stack.resolve()),
   )
 
   // Check stack status
@@ -43,7 +43,7 @@ export default async function del(
           tracker.interruptInfo(`Stack ${stackName} already deleted`)
           return id
         }
-      })
+      }),
     )
   ).filter(Boolean)
 
@@ -86,7 +86,7 @@ export default async function del(
     })
     // Add the confirmed stacks to the list
     Object.values(confirmedIds).forEach(
-      (id) => (stacksToDelete[id] = _stacks[id])
+      (id) => (stacksToDelete[id] = _stacks[id]),
     )
   }
 

--- a/src/pacploy/deploy/createChangeSet.js
+++ b/src/pacploy/deploy/createChangeSet.js
@@ -26,7 +26,7 @@ import credentialDefaultProvider from "../credentialDefaultProvider.js"
  */
 export default async function createChangeSet(
   stack,
-  { quiet = false, attempts = 0 }
+  { quiet = false, attempts = 0 },
 ) {
   const { region, stackName } = stack
   const cf = new CloudFormationClient({
@@ -43,7 +43,7 @@ export default async function createChangeSet(
     ;({ Id: changeSetArn } = await call(
       cf,
       cf.send,
-      new CreateChangeSetCommand(args)
+      new CreateChangeSetCommand(args),
     ))
   } catch (err) {
     if (

--- a/src/pacploy/deploy/deleteChangeSets.js
+++ b/src/pacploy/deploy/deleteChangeSets.js
@@ -43,20 +43,20 @@ export default async function deleteChangeSets({
         await call(
           cf,
           cf.send,
-          new DeleteChangeSetCommand({ ChangeSetName: changeSetId })
+          new DeleteChangeSetCommand({ ChangeSetName: changeSetId }),
         )
         changeSetsDeleted.push(changeSetId)
         tracker.setStatus(
           [
             `${changeSetsDeleted.length} of ${changeSetsToDelete.length}`,
             "change sets deleted",
-          ].join(" ")
+          ].join(" "),
         )
       } catch (err) {
         tracker.interruptError(`Failed to delete change set ${changeSetId}`)
         throw err
       }
-    })
+    }),
   )
   return changeSetsDeleted
 }

--- a/src/pacploy/deploy/deployStack.js
+++ b/src/pacploy/deploy/deployStack.js
@@ -35,7 +35,7 @@ export default async function deployStack(stack) {
     // Create root change set
     const { changeSetArn, hasChanges } = await createChangeSet(
       new ResolvedStackParams({ ...resolved, templatePath: templateURL }),
-      { quiet: true }
+      { quiet: true },
     )
     if (hasChanges) {
       const cf = new CloudFormationClient({
@@ -47,7 +47,7 @@ export default async function deployStack(stack) {
       await call(
         cf,
         cf.send,
-        new ExecuteChangeSetCommand({ ChangeSetName: changeSetArn })
+        new ExecuteChangeSetCommand({ ChangeSetName: changeSetArn }),
       )
       deployStarted = true
       const deployStatus = await waitForStatus({
@@ -76,7 +76,7 @@ export default async function deployStack(stack) {
       await errors({ region: stack.region, stackName: stack.stackName })
     else
       tracker.interruptError(
-        `Failed to deploy stack ${stack.stackName}: ${err}`
+        `Failed to deploy stack ${stack.stackName}: ${err}`,
       )
     process.exitCode = 1
     return false

--- a/src/pacploy/deploy/deployStacks.js
+++ b/src/pacploy/deploy/deployStacks.js
@@ -33,13 +33,13 @@ export default async function deployStacks(stacks) {
         if (dependents.length > 0) {
           // If stack had dependents, warn they won't be deployed
           const uniqueNames = new Set(
-            dependents.map(({ stackName }) => stackName)
+            dependents.map(({ stackName }) => stackName),
           )
           const s = uniqueNames.size > 1 ? "s" : ""
           tracker.interruptWarn(
             `Skipped deployment of ${
               uniqueNames.size
-            } dependent stack${s}: ${Array.from(uniqueNames).join(", ")}`
+            } dependent stack${s}: ${Array.from(uniqueNames).join(", ")}`,
           )
         }
         return // Don't process further stacks
@@ -49,7 +49,7 @@ export default async function deployStacks(stacks) {
       updateTracker(stacks)
       // Recursively deploy stacks that may depend on the current one
       return deployStacks(stacks)
-    })
+    }),
   )
 }
 
@@ -61,14 +61,14 @@ export default async function deployStacks(stacks) {
 function updateTracker(stacks) {
   const total = stacks.length
   const left = stacks.filter(
-    ({ deploymentStatus }) => !["success", "failed"].includes(deploymentStatus)
+    ({ deploymentStatus }) => !["success", "failed"].includes(deploymentStatus),
   ).length
   const inProgress = stacks.filter(
-    ({ deploymentStatus }) => deploymentStatus === "in progress"
+    ({ deploymentStatus }) => deploymentStatus === "in progress",
   ).length
   if (total > 1)
     tracker.setStatus(
-      `deploying ${total} stacks (${left} left, ${inProgress} in progress)`
+      `deploying ${total} stacks (${left} left, ${inProgress} in progress)`,
     )
   else tracker.setStatus(`deploying stack`)
 }
@@ -90,8 +90,8 @@ function getStacksReadyToDeploy(stacks) {
       getDependencies({ dependsOn }, stacks).reduce(
         (allDeployed, { deploymentStatus }) =>
           allDeployed && deploymentStatus === "success",
-        true
-      )
+        true,
+      ),
   )
 }
 
@@ -139,8 +139,8 @@ function getDependents({ region, stackName }, stacks) {
           dependents = dependents.concat(
             getDependents(
               { region: stack.region, stackName: stack.stackName },
-              stacks
-            )
+              stacks,
+            ),
           )
           break
         }

--- a/src/pacploy/deploy/getChangeSetArgs.js
+++ b/src/pacploy/deploy/getChangeSetArgs.js
@@ -59,14 +59,14 @@ export default async function getChangeSetArgs({
                   : Array.isArray(ParameterValue)
                   ? ParameterValue.join(",")
                   : JSON.stringify(ParameterValue),
-            }
-      )
+            },
+      ),
     )
     .filter(
       ({ ParameterKey }) =>
         requiredParameters
           .map(({ ParameterKey }) => ParameterKey) // Required param keys
-          .includes(ParameterKey) // Current provided key
+          .includes(ParameterKey), // Current provided key
     )
   // Build tags (change format)
   const Tags =
@@ -90,6 +90,6 @@ export default async function getChangeSetArgs({
       Parameters,
       Tags,
     },
-    templateArg
+    templateArg,
   )
 }

--- a/src/pacploy/deploy/getChangeSets.js
+++ b/src/pacploy/deploy/getChangeSets.js
@@ -34,7 +34,7 @@ export default async function getChangeSets({
     new ListChangeSetsCommand({
       StackName: stackName,
       NextToken: nextToken,
-    })
+    }),
   )
   // Append the changes to the list
   changeSets = changeSets.concat(Summaries)

--- a/src/pacploy/deploy/index.js
+++ b/src/pacploy/deploy/index.js
@@ -15,7 +15,7 @@ export default async function deploy(stacks) {
   if (
     stacks.reduce(
       (hasForceDelete, { forceDelete }) => hasForceDelete || forceDelete,
-      false
+      false,
     )
   )
     // Warn user that we'll not ask for confirmation before deleting
@@ -38,7 +38,9 @@ export default async function deploy(stacks) {
   // Validate templates
   tracker.setStatus(`validating template${s}`)
   await Promise.all(
-    stacks.map(({ region, templatePath }) => validate({ region, templatePath }))
+    stacks.map(({ region, templatePath }) =>
+      validate({ region, templatePath }),
+    ),
   )
 
   // Prepare stacks for deployment
@@ -47,7 +49,7 @@ export default async function deploy(stacks) {
     stacks.map(async (stack) => {
       const stackStatus = await prepare(stack)
       stacks[stack.index].stackStatus = stackStatus
-    })
+    }),
   )
 
   // Deploy the stacks

--- a/src/pacploy/deploy/prepare.js
+++ b/src/pacploy/deploy/prepare.js
@@ -32,7 +32,7 @@ export default async function prepare(stack) {
         [
           `Stack is in status ${status}`,
           `and needs to be deleted before attempting to create it again`,
-        ].join(" ")
+        ].join(" "),
       )
     // Delete stack
     await del(stack, { warnAboutForceDelete: false })

--- a/src/pacploy/deploy/validate.js
+++ b/src/pacploy/deploy/validate.js
@@ -28,7 +28,7 @@ export default async function validate({ region, templatePath }) {
       new ValidateTemplateCommand({
         // Open template as string
         TemplateBody: readFileSync(templatePath, "utf8"),
-      })
+      }),
     )
     return true
   } catch (err) {

--- a/src/pacploy/errors/displayEvents.js
+++ b/src/pacploy/errors/displayEvents.js
@@ -10,14 +10,14 @@ import colors from "ansi-colors"
 export default function displayEvents(
   { ResourceStatus, ResourceStatusReason, LogicalResourceId, resources = {} },
   delimiter = " ",
-  indentation = 1
+  indentation = 1,
 ) {
   // Display current stack event
   if (ResourceStatus)
     tracker.interrupt(
       `${delimiter.repeat(indentation)}${colors.bold.red(
-        `\u2717 ${LogicalResourceId} ${ResourceStatus}`
-      )}${ResourceStatusReason ? `: ${ResourceStatusReason}` : ""}`
+        `\u2717 ${LogicalResourceId} ${ResourceStatus}`,
+      )}${ResourceStatusReason ? `: ${ResourceStatusReason}` : ""}`,
     )
   // Display nested resources if any
   if (Object.keys(resources).length > 0)

--- a/src/pacploy/errors/index.js
+++ b/src/pacploy/errors/index.js
@@ -43,7 +43,7 @@ export default async function getErrors({
       new DescribeStackEventsCommand({
         StackName: stackName,
         NextToken: nextToken,
-      })
+      }),
     )
     nextToken = NextToken // Update the token
     if (!eventsPage.length) return // If no events were found
@@ -60,7 +60,7 @@ export default async function getErrors({
         // Event describes the stack in a stable status
         stableStatuses.includes(ResourceStatus) &&
         // Event is older than our upper boundary
-        Timestamp < timestamp1
+        Timestamp < timestamp1,
     )
     if (nextStackEvents.length) timestamp2 = nextStackEvents[0].Timestamp
     lastTimestamp = eventsPage[eventsPage.length - 1].Timestamp
@@ -72,7 +72,7 @@ export default async function getErrors({
         (Timestamp > timestamp2 || !timestamp2) &&
         // Event is an error
         /[A-Z]+_FAILED$/.test(ResourceStatus) &&
-        ResourceStatusReason !== "Resource creation cancelled"
+        ResourceStatusReason !== "Resource creation cancelled",
     )
     // Add relevant events
     events = events.concat(nextEvents)
@@ -91,7 +91,7 @@ export default async function getErrors({
         StackId,
         PhysicalResourceId,
         ResourceType,
-      }
+      },
     ) => {
       errors = await errors // Retrieve object, since this is an async reduce
       if (StackId !== PhysicalResourceId) {
@@ -120,13 +120,13 @@ export default async function getErrors({
                 timestamp1,
                 timestamp2,
                 parentStackId: parentStackId || StackId,
-              })
+              }),
             )
         }
       }
       return errors
     },
-    Promise.resolve({})
+    Promise.resolve({}),
   )
   if (!parentStackId) {
     // Display errors before final return

--- a/src/pacploy/getStatus/index.js
+++ b/src/pacploy/getStatus/index.js
@@ -16,7 +16,7 @@ import credentialDefaultProvider from "../credentialDefaultProvider.js"
  */
 export default async function getStatus(
   { region, stackName },
-  { quiet = true } = {}
+  { quiet = true } = {},
 ) {
   const cf = new CloudFormationClient({
     apiVersion: "2010-05-15",
@@ -30,7 +30,7 @@ export default async function getStatus(
     const { Stacks: [{ StackStatus }] = [] } = await call(
       cf,
       cf.send,
-      new DescribeStacksCommand({ StackName: stackName })
+      new DescribeStacksCommand({ StackName: stackName }),
     )
     status = StackStatus
   } catch (err) {

--- a/src/pacploy/params/index.js
+++ b/src/pacploy/params/index.js
@@ -97,9 +97,9 @@ export default class StackParams {
                     return {
                       [stackName]: await getStackOutputs({ region, stackName }),
                     }
-                })
+                }),
               )
-            ).filter(Boolean)
+            ).filter(Boolean),
           )
         : {}
     // Return processed arguments

--- a/src/pacploy/pkg/File.js
+++ b/src/pacploy/pkg/File.js
@@ -21,7 +21,7 @@ export default class File {
    */
   constructor(
     path,
-    { resourceType, propName, packageTo, status = "pending", dependsOn = [] }
+    { resourceType, propName, packageTo, status = "pending", dependsOn = [] },
   ) {
     this.path = path
     this.originalPath = path // Keep track as file path may be changed

--- a/src/pacploy/pkg/ResourceProperty.js
+++ b/src/pacploy/pkg/ResourceProperty.js
@@ -192,7 +192,7 @@ const packingList = {
             res.S3.push(propValue[arg]) // Add the file
           return res
         },
-        { S3: [] }
+        { S3: [] },
       ),
     packaged: (propValue) =>
       awsGlueJobDefaultArgumentsToPackage.reduce(
@@ -201,7 +201,7 @@ const packingList = {
             res.S3.push(parseS3Uri(propValue[arg])) // Add the file
           return res
         },
-        { S3: [] }
+        { S3: [] },
       ),
     update: (propValue, locations) =>
       Object.assign(
@@ -210,12 +210,12 @@ const packingList = {
           // Keep only the arguments that were not already packaged
           .filter(
             (arg) =>
-              propValue[arg] !== undefined && !isValidS3Uri(propValue[arg])
+              propValue[arg] !== undefined && !isValidS3Uri(propValue[arg]),
           )
           .map((arg) => ({
             // Replace the argument's value with the packaged location
             [arg]: getS3Uri(parseS3Uri(locations[propValue[arg]])),
-          }))
+          })),
       ),
   },
   "AWS::Include.Location": {
@@ -269,7 +269,7 @@ const packingList = {
           if (!isValidECRUri(Image)) res.ECR.push(Image)
           return res
         },
-        { ECR: [] }
+        { ECR: [] },
       ),
     packaged: (propValue) =>
       propValue.reduce(
@@ -278,14 +278,14 @@ const packingList = {
           if (isValidECRUri(Image)) res.ECR.push(Image)
           return res
         },
-        { ECR: [] }
+        { ECR: [] },
       ),
     update: (propValue, locations) =>
       propValue.map((def) =>
         Object.assign(
           def,
-          !isValidECRUri(def.Image) && { Image: locations[def.Image] }
-        )
+          !isValidECRUri(def.Image) && { Image: locations[def.Image] },
+        ),
       ),
   },
   "AWS::CodeBuild::Project.Environment": {
@@ -329,7 +329,7 @@ const packingList = {
           typeof propValue.ApplicationCodeConfiguration.CodeContent
             .TextContent === "string" &&
           propValue.ApplicationCodeConfiguration.CodeContent.TextContent.startsWith(
-            "."
+            ".",
           )
         ? {
             INLINE: [
@@ -349,7 +349,7 @@ const packingList = {
                 // S3 bucket name is after the ':::'
                 Bucket: /.*:::(?<name>.+)$/.exec(
                   propValue.ApplicationCodeConfiguration.CodeContent
-                    .S3ContentLocation.BucketARN
+                    .S3ContentLocation.BucketARN,
                 ).groups.name,
                 Key: propValue.ApplicationCodeConfiguration.CodeContent
                   .S3ContentLocation.FileKey,
@@ -364,7 +364,7 @@ const packingList = {
           s3Location,
         [propValue.ApplicationCodeConfiguration.CodeContent.TextContent]:
           tmpLocation,
-      }
+      },
     ) =>
       Object.assign(propValue, {
         ApplicationCodeConfiguration: Object.assign(
@@ -385,9 +385,9 @@ const packingList = {
                 : tmpLocation
                 ? // Replace local path with file content
                   { TextContent: readFileSync(tmpLocation, "utf8") }
-                : {}
+                : {},
             ),
-          }
+          },
         ),
       }),
   },
@@ -406,7 +406,7 @@ const packingList = {
         : {},
     update: (
       propValue,
-      { [propValue.ImageRepository.ImageIdentifier]: location }
+      { [propValue.ImageRepository.ImageIdentifier]: location },
     ) =>
       Object.assign(propValue, {
         ImageRepository: Object.assign(propValue.ImageRepository, {
@@ -447,7 +447,7 @@ function isValidS3Uri(uri) {
 function isValidECRUri(uri) {
   // Source: https://stackoverflow.com/questions/39671641
   return new RegExp(
-    "^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])(:[0-9]+\\/)?(?:[0-9a-z-]+[/@])(?:([0-9a-z-]+))[/@]?(?:([0-9a-z-]+))?(?::[a-z0-9\\.-]+)?$"
+    "^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])(:[0-9]+\\/)?(?:[0-9a-z-]+[/@])(?:([0-9a-z-]+))[/@]?(?:([0-9a-z-]+))?(?::[a-z0-9\\.-]+)?$",
   ).test(uri)
 }
 

--- a/src/pacploy/pkg/getFilesToPackage.js
+++ b/src/pacploy/pkg/getFilesToPackage.js
@@ -21,7 +21,7 @@ export default function getFilesToPackage(templatePath) {
       const resourceProp = new ResourceProperty(
         resourceType,
         propName,
-        propValue
+        propValue,
       )
       if (!Object.keys(toPackage).includes(curTemplatePath))
         // If current template has not yet been identified, register it
@@ -46,7 +46,7 @@ export default function getFilesToPackage(templatePath) {
           toPackage[curTemplatePath].dependsOn.push(filePath)
         }
       }
-    }
+    },
   )
   if (
     Object.keys(toPackage).length === 1 &&

--- a/src/pacploy/pkg/getFullPath.js
+++ b/src/pacploy/pkg/getFullPath.js
@@ -17,7 +17,7 @@ export default function getFullPath(path, relToPath = process.cwd()) {
   // Calculate the full path (use file's dirname if relevant)
   const fullPath = resolve(
     isDir(relToPath) ? relToPath : dirname(relToPath),
-    path
+    path,
   )
   // Append a trailing slash if result is a directory
   return isDir(fullPath) ? appendSlash(fullPath) : fullPath

--- a/src/pacploy/pkg/index.js
+++ b/src/pacploy/pkg/index.js
@@ -31,13 +31,13 @@ export default async function pkg(stacks, { quiet = false } = {}) {
   // Package templates
   const filesCount = stacksToPackage.reduce(
     (count, { toPackage }) => count + Object.keys(toPackage).length,
-    0
+    0,
   )
   if (!quiet) tracker.setStatus(`packaging ${filesCount} files`)
   const packagedTemplates = await Promise.all(
     stacksToPackage.map(({ toPackage, ...stack }) =>
-      packageFiles(toPackage, new StackParams(stack))
-    )
+      packageFiles(toPackage, new StackParams(stack)),
+    ),
   )
 
   // Verify that all files were packaged
@@ -46,7 +46,7 @@ export default async function pkg(stacks, { quiet = false } = {}) {
     const actual = Object.keys(packagedTemplates[index]).length
     if (actual !== expected)
       throw new Error(
-        `Expected to package ${expected} files, but ${actual} were packaged`
+        `Expected to package ${expected} files, but ${actual} were packaged`,
       )
   }
 
@@ -56,16 +56,16 @@ export default async function pkg(stacks, { quiet = false } = {}) {
       count +
       Object.values(packagedFiles).filter(({ status }) => status !== "exists")
         .length,
-    0
+    0,
   )
   const totalCount = packagedTemplates.reduce(
     (count, packagedFiles) => count + Object.keys(packagedFiles).length,
-    0
+    0,
   )
   if (!quiet)
     if (newCount > 0)
       tracker.interruptSuccess(
-        `${newCount} new files packaged (${totalCount} in total)`
+        `${newCount} new files packaged (${totalCount} in total)`,
       )
     else
       tracker.interruptInfo(`No new files to package (${totalCount} in total)`)
@@ -77,7 +77,7 @@ export default async function pkg(stacks, { quiet = false } = {}) {
     paths.push(
       Object.keys(packagedTemplates[index]).includes(templatePath)
         ? packagedTemplates[index][templatePath].location
-        : templatePath
+        : templatePath,
     )
   return paths
 }

--- a/src/pacploy/pkg/listPackagedFiles.js
+++ b/src/pacploy/pkg/listPackagedFiles.js
@@ -39,7 +39,7 @@ export default async function listPackagedFiles({
     new GetTemplateCommand({
       StackName: stackName,
       TemplateStage: "Processed",
-    })
+    }),
   )
   if (deployBucket) {
     // If the template's deployBucket was passed, recalculate its key as it is
@@ -51,7 +51,7 @@ export default async function listPackagedFiles({
         StackName: stackName,
         // Use the original content as it was used to calculate the hash
         TemplateStage: "Original",
-      })
+      }),
     )
     packaged.push({
       region,
@@ -67,7 +67,7 @@ export default async function listPackagedFiles({
       const resourceProp = new ResourceProperty(
         resourceType,
         propName,
-        propValue
+        propValue,
       )
       if (resourceProp.packaged.S3) {
         // If current resource has files packaged to S3
@@ -76,7 +76,7 @@ export default async function listPackagedFiles({
             !packaged.reduce(
               (res, { Bucket: curBucket, Key: curKey }) =>
                 res || (bucket === curBucket && key === curKey),
-              false
+              false,
             )
           )
             // If current resource was not identified yet, add it to the list

--- a/src/pacploy/pkg/packageFile.js
+++ b/src/pacploy/pkg/packageFile.js
@@ -40,6 +40,6 @@ export default async function packageFile({
   // If packageTo was not recognized
   throw new Error(
     `Unable to determine where file '${file.path}' should be packaged` +
-      ` (value '${file.packageTo}' not recognized)`
+      ` (value '${file.packageTo}' not recognized)`,
   )
 }

--- a/src/pacploy/pkg/packageFileInline.js
+++ b/src/pacploy/pkg/packageFileInline.js
@@ -20,7 +20,7 @@ export default async function packageFileInline(file, { forceUpload = false }) {
   if (forceUpload || status !== "exists") {
     // If object doesn't exist yet, or upload was forced: update it
     await new Promise((res, rej) =>
-      copyFile(file.path, targetPath, (err) => (err ? rej(err) : res()))
+      copyFile(file.path, targetPath, (err) => (err ? rej(err) : res())),
     )
     status = status === "exists" ? "forced" : "updated"
   }

--- a/src/pacploy/pkg/packageFileToECR.js
+++ b/src/pacploy/pkg/packageFileToECR.js
@@ -25,7 +25,7 @@ const docker = new Docker()
  */
 export default async function packageFileToECR(
   file,
-  { region, deployEcr, forceUpload = false }
+  { region, deployEcr, forceUpload = false },
 ) {
   // Retrieve parameters, if any
   // Resolve root directory relative to the config file
@@ -74,7 +74,7 @@ export default async function packageFileToECR(
   // Build the image
   const buildStream = await docker.buildImage(
     file.path,
-    Object.assign({ t: imageName, nocache: forceUpload }, dockerBuild)
+    Object.assign({ t: imageName, nocache: forceUpload }, dockerBuild),
   )
   await waitFor(buildStream)
   // Push the image to the repository (this will only push layers that have
@@ -126,7 +126,7 @@ async function getToken(region) {
       // registryIds is not passed (it tries to read properties of undefined).
       // A future update may make passing registryIds optional again, as it
       // seems that the permissions are not impacted
-      new GetAuthorizationTokenCommand({ registryIds: ["000000000000"] })
+      new GetAuthorizationTokenCommand({ registryIds: ["000000000000"] }),
     )
   const [username, password] = Buffer.from(authorizationToken, "base64")
     .toString()
@@ -154,9 +154,9 @@ function waitFor(stream) {
           reject(
             logs
               .map((log) =>
-                (log.error || log.stream || JSON.stringify(log)).trim()
+                (log.error || log.stream || JSON.stringify(log)).trim(),
               )
-              .join("\n")
+              .join("\n"),
           )
         else resolve(logs.map((log) => log.stream || log))
       }

--- a/src/pacploy/pkg/packageFileToS3.js
+++ b/src/pacploy/pkg/packageFileToS3.js
@@ -32,7 +32,7 @@ import { getTags, tagDelimiter } from "../cleanup/listBucket.js"
  */
 export default async function packageFileToS3(
   file,
-  { region, deployBucket, dependencies, forceUpload = false, stackTags = {} }
+  { region, deployBucket, dependencies, forceUpload = false, stackTags = {} },
 ) {
   const s3 = new S3Client({
     apiVersion: "2006-03-01",
@@ -74,7 +74,7 @@ export default async function packageFileToS3(
     await call(
       s3,
       s3.send,
-      new HeadObjectCommand({ Bucket: deployBucket, Key: key })
+      new HeadObjectCommand({ Bucket: deployBucket, Key: key }),
     )
     exists = true
     status = "exists"
@@ -123,13 +123,13 @@ async function updateTags(stackTags, region, bucket, key) {
 
   // Merge values in case multiple stacks use the same file
   const allKeys = Array.from(
-    new Set(Object.keys(existingTags).concat(Object.keys(stackTags)))
+    new Set(Object.keys(existingTags).concat(Object.keys(stackTags))),
   )
   const tagsToApply = allKeys.reduce((merged, key) => {
     const existing = existingTags[key] || []
     const updated = stackTags[key] ? [stackTags[key]] : []
     merged[key] = Array.from(new Set(existing.concat(updated))).join(
-      tagDelimiter
+      tagDelimiter,
     )
     return merged
   }, {})
@@ -147,6 +147,6 @@ async function updateTags(stackTags, region, bucket, key) {
           Value,
         })),
       },
-    })
+    }),
   )
 }

--- a/src/pacploy/pkg/packageFiles.js
+++ b/src/pacploy/pkg/packageFiles.js
@@ -20,7 +20,7 @@ export default async function packageFiles(toPackage, stack) {
     else if (file.packageTo === "ECR" && !resolved.deployEcr)
       // If the file's destination is ECR but a repository is missing
       throw new Error(
-        `A docker repository is missing to package ${resolved.templatePath}`
+        `A docker repository is missing to package ${resolved.templatePath}`,
       )
 
   // Package all the files for all templates
@@ -54,11 +54,11 @@ async function _packageFiles(toPackage, stack) {
           dependencies: getDependencies(file, toPackage),
           stackTags,
           forceUpload,
-        })
+        }),
       )
       // Recursively package files that may depend on the current file
       return _packageFiles(toPackage, stack)
-    })
+    }),
   )
   return toPackage
 }
@@ -78,8 +78,8 @@ function getFilesReadyToPackage(toPackage) {
       // And whose dependencies have all been packaged already
       file.dependsOn.reduce(
         (allPackaged, path) => allPackaged && Boolean(toPackage[path].location),
-        true
-      )
+        true,
+      ),
   )
 }
 

--- a/src/pacploy/pkg/parseRemoteTemplate.js
+++ b/src/pacploy/pkg/parseRemoteTemplate.js
@@ -40,7 +40,7 @@ export default async function parseRemoteTemplate({
               const { packaged } = new ResourceProperty(
                 resourceType,
                 propName,
-                propValue
+                propValue,
               )
               if (packaged.S3) {
                 // If the nested template is packaged to S3
@@ -48,7 +48,7 @@ export default async function parseRemoteTemplate({
                 const { Body } = await call(
                   s3,
                   s3.send,
-                  new GetObjectCommand({ Bucket, Key })
+                  new GetObjectCommand({ Bucket, Key }),
                 )
                 // Recursively parse it
                 await parseRemoteTemplate({
@@ -64,8 +64,8 @@ export default async function parseRemoteTemplate({
               propName,
               propValue,
             })
-          })
-        )
-    )
+          }),
+        ),
+    ),
   )
 }

--- a/src/pacploy/pkg/parseTemplateFile.js
+++ b/src/pacploy/pkg/parseTemplateFile.js
@@ -34,6 +34,6 @@ export default function parseTemplateFile(templatePath, fn) {
           propValue,
         })
       })
-    }
+    },
   )
 }

--- a/src/pacploy/pkg/updateTemplate.js
+++ b/src/pacploy/pkg/updateTemplate.js
@@ -23,7 +23,7 @@ export default function updateTemplate(templatePath, { dependencies }) {
       const resourceProp = new ResourceProperty(
         resourceType,
         propName,
-        propValue
+        propValue,
       )
       // Combine all files to package across destinations and map their
       // absolute path to their relative one
@@ -33,9 +33,9 @@ export default function updateTemplate(templatePath, { dependencies }) {
             toPackage,
             ...relPaths.map((relPath) => ({
               [getFullPath(relPath, templatePath)]: relPath,
-            }))
+            })),
           ),
-        {}
+        {},
       )
       if (Object.keys(toPackage).length > 0)
         // If current property has files to package, replace its value with the
@@ -53,8 +53,8 @@ export default function updateTemplate(templatePath, { dependencies }) {
                   res[toPackage[originalPath]] = location
                 return res
               },
-              {}
-            )
+              {},
+            ),
           )
     }
   }

--- a/src/pacploy/sync/getStackOutputs.js
+++ b/src/pacploy/sync/getStackOutputs.js
@@ -22,11 +22,11 @@ export default async function getStackInfo({ region, stackName }) {
   const { Stacks: [{ Outputs = [] }] = [] } = await call(
     cf,
     cf.send,
-    new DescribeStacksCommand({ StackName: stackName })
+    new DescribeStacksCommand({ StackName: stackName }),
   )
   // Serialize the output format
   return Outputs.reduce(
     (res, val) => Object.assign(res, { [val.OutputKey]: val.OutputValue }),
-    {}
+    {},
   )
 }

--- a/src/pacploy/sync/index.js
+++ b/src/pacploy/sync/index.js
@@ -29,7 +29,7 @@ export default async function sync(stacks, params) {
  */
 async function syncStack(
   { region, stackName, syncPath = [], noOverride },
-  { quiet = false } = {}
+  { quiet = false } = {},
 ) {
   // Convert syncPath to a list
   const syncPaths = Array.isArray(syncPath)
@@ -42,7 +42,7 @@ async function syncStack(
     else
       tracker.interruptWarn(
         `Skipped sync of stack ${stackName} to ${path}:` +
-          " file already exists and noOverride is set"
+          " file already exists and noOverride is set",
       )
     return res
   }, [])
@@ -53,7 +53,7 @@ async function syncStack(
   if (!availableStatuses.includes(status)) {
     // If stack is in a non available status
     tracker.interruptError(
-      `Stack ${stackName} is not available to sync (${status})`
+      `Stack ${stackName} is not available to sync (${status})`,
     )
     return
   }
@@ -69,16 +69,16 @@ async function syncStack(
         const wasUpdated = await syncOutputs(outputs, path)
         if (wasUpdated)
           tracker.interruptSuccess(
-            `Stack ${stackName} outputs synced at ${path}`
+            `Stack ${stackName} outputs synced at ${path}`,
           )
         else
           tracker.interruptInfo(`Stack ${stackName} outputs already up-to-date`)
       } catch (err) {
         tracker.interruptError(
-          `Failed to sync stack ${stackName} outputs to ${path}: ` + err
+          `Failed to sync stack ${stackName} outputs to ${path}: ` + err,
         )
       }
-    })
+    }),
   )
 
   return outputs
@@ -137,8 +137,8 @@ const formats = {
           Object.entries(curr).reduce((formatted, [key, value]) => {
             formatted[camelToMacroCase(key)] = value
             return formatted
-          }, {})
-        )
+          }, {}),
+        ),
       )
         // Escape specialy characters in the value
         .map(([key, value]) => `${key}=${JSON.stringify(value)}`)

--- a/src/pacploy/sync/index.js
+++ b/src/pacploy/sync/index.js
@@ -1,11 +1,10 @@
 import tracker from "../tracker.js"
-import { existsSync, readFileSync, writeFileSync } from "fs"
+import { existsSync, readFileSync, writeFileSync, appendFileSync } from "fs"
 import { available as availableStatuses } from "../statuses.js"
 import getStackOutputs from "./getStackOutputs.js"
 import getStatus from "../getStatus/index.js"
 import md5 from "../pkg/md5.js"
 import { basename, extname } from "path"
-import dotenv from "dotenv"
 
 /**
  * Download outputs of a deployed stack(s) into a local file(s)
@@ -99,50 +98,50 @@ async function syncOutputs(newOutputs, path) {
   // Check if file format is supported
   if (!Object.keys(formats).includes(extension))
     throw new Error(`unsupported file format (${extension})`)
-  // If format is supported, retrieve its parser and serializer
-  const { parse, stringify } = formats[extension]
-  // Check if file exists
-  const exists = existsSync(path)
+  // If format is supported, retrieve how to update the target file
+  const update = formats[extension]
   // Retrieve existing file's hash, if any
-  const hashBefore = exists ? await md5(path) : undefined
-  // Load previous file content if it exists
-  const existingOutputs = exists ? parse(readFileSync(path, "utf8")) : {}
+  const hashBefore = existsSync(path) ? await md5(path) : undefined
   // Merge with the new outputs and update the file
-  writeFileSync(path, stringify(existingOutputs, newOutputs), "utf8")
+  update(newOutputs, path)
+  // Check updated file's hash
   const hashAfter = await md5(path)
   return hashAfter !== hashBefore
 }
 
 /**
- * Define the parsers and serializer of files in different formats. The parser
- * takes the existing file's contents and returns a key/value map. The
- * serializer takes the pre-existing and new key/value maps and returns the
- * file's content to write
+ * Define how new outputs are written in the target file
  * @type {Object<String, {parse: Function, stringify: Function}>}
  */
 const formats = {
-  ".json": {
-    parse: JSON.parse,
-    stringify: (prev, curr) => JSON.stringify(Object.assign({}, prev, curr)),
+  ".json": (newOutputs, path) => {
+    // Retrieve existing values if the target file exists
+    const existingValues = existsSync(path)
+      ? JSON.parse(readFileSync(path, "utf8"))
+      : {}
+    // Merge with the new outputs and update the file
+    const merged = Object.assign({}, existingValues, newOutputs)
+    // Update the target file
+    writeFileSync(path, JSON.stringify(merged), "utf8")
   },
-  ".env": {
-    parse: dotenv.parse,
-    stringify: (prev, curr) =>
-      Object.entries(
-        Object.assign(
-          {},
-          prev,
-          // Convert the new outputs keys to MACRO_CASE to properly merge them
-          // with existing keys
-          Object.entries(curr).reduce((formatted, [key, value]) => {
-            formatted[camelToMacroCase(key)] = value
-            return formatted
-          }, {}),
-        ),
-      )
-        // Escape specialy characters in the value
-        .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
+  ".env": (newOutputs, path) => {
+    // If the target file exists, add a line break at the end
+    if (existsSync(path)) appendFileSync(path, "\n", "utf8")
+    // To avoid conflicts, we leave any existing values untouched
+    // and only add new ones
+    appendFileSync(
+      path,
+      // Convert the new outputs keys to MACRO_CASE  and escape specialy
+      // characters in the value
+      Object.entries(newOutputs)
+        .map(
+          ([key, value]) => `${camelToMacroCase(key)}=${JSON.stringify(value)}`,
+        )
         .join("\n"),
+      "utf8",
+    )
+    // Append a line break at the end of the file
+    appendFileSync(path, "\n", "utf8")
   },
 }
 

--- a/src/pacploy/throttle.test.js
+++ b/src/pacploy/throttle.test.js
@@ -24,7 +24,7 @@ describe("throttle", () => {
     test1 = new Promise((res) => {
       const interval = setInterval(() => {
         attempted.push(
-          throttled1().catch((err) => err.name === "AbortError" && aborted++)
+          throttled1().catch((err) => err.name === "AbortError" && aborted++),
         )
         if (attempted.length === 20) {
           clearInterval(interval) // Stop executing the function
@@ -51,10 +51,10 @@ describe("throttle", () => {
       await new Promise((res) => {
         const interval = setInterval(() => {
           attempted.push(
-            throttled1().catch((err) => err.name === "AbortError" && aborted++)
+            throttled1().catch((err) => err.name === "AbortError" && aborted++),
           )
           attempted.push(
-            throttled2().catch((err) => err.name === "AbortError" && aborted++)
+            throttled2().catch((err) => err.name === "AbortError" && aborted++),
           )
           if (attempted.length === 40) {
             clearInterval(interval) // Stop executing the functions
@@ -75,19 +75,19 @@ describe("throttle", () => {
 
   test("limits requests from a single function in the interval", async () => {
     await expect(test1).resolves.toEqual(
-      expect.objectContaining({ attempted: 20, executed: 5, aborted: 0 })
+      expect.objectContaining({ attempted: 20, executed: 5, aborted: 0 }),
     )
   })
 
   test("processes all requests while meeting rate limit", async () => {
     await expect(test2).resolves.toEqual(
-      expect.objectContaining({ attempted: 20, executed: 20, aborted: 0 })
+      expect.objectContaining({ attempted: 20, executed: 20, aborted: 0 }),
     )
   })
 
   test("limits requests from multiple functions in the interval", async () => {
     await expect(test3).resolves.toEqual(
-      expect.objectContaining({ attempted: 40, executed: 5, aborted: 0 })
+      expect.objectContaining({ attempted: 40, executed: 5, aborted: 0 }),
     )
   })
 

--- a/src/pacploy/tracker.js
+++ b/src/pacploy/tracker.js
@@ -100,9 +100,9 @@ export class Tracker extends ProgressBar {
         Object.entries(this._tokens).reduce(
           (width, [token, value]) =>
             token === "status" ? width : width + value.length,
-          0
+          0,
         ) -
-        2 // Additional buffer to ensure there is no line wrap
+        2, // Additional buffer to ensure there is no line wrap
     )
     // Start the spinner if needed
     if ((!this.spinner || this.spinner._destroyed) && this.curr < this.total)

--- a/src/pacploy/waitForStatus/index.js
+++ b/src/pacploy/waitForStatus/index.js
@@ -35,7 +35,7 @@ export default async function waitForStatus({
   })
   // Check if the supplied arn is that of a change set or a stack
   const isChangeSet = /arn:aws:cloudformation:[^:]+:[^:]+:changeSet\/.+/.test(
-    arn
+    arn,
   )
   let status, statusReason
   do {
@@ -45,7 +45,7 @@ export default async function waitForStatus({
       ;({ Status: status, StatusReason: statusReason } = await call(
         cf,
         cf.send,
-        new DescribeChangeSetCommand({ ChangeSetName: arn })
+        new DescribeChangeSetCommand({ ChangeSetName: arn }),
       ))
     } else {
       // Retrieve status of a stack
@@ -56,7 +56,7 @@ export default async function waitForStatus({
       } = await call(
         cf,
         cf.send,
-        new DescribeStacksCommand({ StackName: arn })
+        new DescribeStacksCommand({ StackName: arn }),
       ))
     }
     if (msg) tracker.setStatus(`${msg} (${status})`)

--- a/src/pacploy/zip/getDependencies.js
+++ b/src/pacploy/zip/getDependencies.js
@@ -17,7 +17,7 @@ export default function getDependencies(
   cwd,
   ignore = new Set(),
   deps = new Map(),
-  bundledDependencies = depList
+  bundledDependencies = depList,
 ) {
   depList.forEach((dep) => {
     // Retrieve the dependency location
@@ -41,7 +41,7 @@ export default function getDependencies(
         dirname(depPath),
         ignore,
         deps,
-        depList // Preserve the original list of dependencies to bundle
+        depList, // Preserve the original list of dependencies to bundle
       )
     }
   })

--- a/src/pacploy/zip/getFilesMatching.js
+++ b/src/pacploy/zip/getFilesMatching.js
@@ -18,7 +18,7 @@ import { stat } from "fs"
  */
 export default async function getFilesMatching(
   patterns,
-  { cwd, ignore = new Set(), ...options } = {}
+  { cwd, ignore = new Set(), ...options } = {},
 ) {
   if (!Array.isArray(patterns)) patterns = [patterns] // Convert to array
   const files = new Set() // Will contain the matching files
@@ -56,6 +56,6 @@ export default async function getFilesMatching(
  */
 async function isDir(path) {
   return await new Promise((res, rej) =>
-    stat(path, (err, stats) => (err ? rej(err) : res(stats.isDirectory())))
+    stat(path, (err, stats) => (err ? rej(err) : res(stats.isDirectory()))),
   )
 }

--- a/src/pacploy/zip/getFilesToZip.js
+++ b/src/pacploy/zip/getFilesToZip.js
@@ -63,10 +63,10 @@ export default async function getFilesToZip(dir, bundleDir) {
         else
           return locatePath(
             [".pacployignore", ".dockerignore", ".npmignore", ".gitignore"],
-            { cwd: currentDir }
+            { cwd: currentDir },
           )
       },
-      { cwd: dir }
+      { cwd: dir },
     )
     ignorePatterns = ignorePath
       ? await readGlobPatterns(ignorePath) // Glob patterns defined in the file
@@ -79,7 +79,7 @@ export default async function getFilesToZip(dir, bundleDir) {
     // If ignorePatterns was provided in the config file, use the root
     // specified in that config file, otherwise match the patterns relative to
     // the ignore file
-    { cwd: ignoreDir }
+    { cwd: ignoreDir },
   )
   // Retrieve files to bundle (map to absolute path)
   const matches = await getFilesMatching(includePatterns, { cwd: root, ignore })
@@ -98,7 +98,7 @@ export default async function getFilesToZip(dir, bundleDir) {
       // Convert symlinks to their target path (same behavior as
       // require.resolve which is used to resolve dependency locations)
       realpath: true,
-    })
+    }),
   )
   // Retrieve files dependencies to bundle
   for (const [depName, depPath] of dependencies.entries()) {
@@ -113,14 +113,14 @@ export default async function getFilesToZip(dir, bundleDir) {
       // folders in symlinked packages in a monorepo
       ignore: await getFilesMatching(
         ignorePatterns.concat(alwaysIgnorePatterns),
-        { cwd: depPath }
+        { cwd: depPath },
       ),
     })
     matches.forEach((path) =>
       files.set(
         resolve(depPath, path),
-        join(bundleDir, depName, path) // Nest under the right dir in archive
-      )
+        join(bundleDir, depName, path), // Nest under the right dir in archive
+      ),
     )
   }
   return files
@@ -140,8 +140,8 @@ async function readGlobPatterns(file) {
             data
               .toString()
               .split("\n")
-              .filter((line) => !line.startsWith("#") && line.length > 0)
-          )
-    )
+              .filter((line) => !line.startsWith("#") && line.length > 0),
+          ),
+    ),
   )
 }


### PR DESCRIPTION
Syncing stack outputs over an existing dotenv file changes the existing values by escaping quotes, which creates undesired conflicts.